### PR TITLE
include cucumber on the dev env

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,3 +6,4 @@ forge 'https://forgeapi.puppetlabs.com'
 mod 'LandRegistry/standard_env',
   :git => 'git://github.com/LandRegistry/standard-env',
   :ref => 'master'
+

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -17,6 +17,7 @@ if versioncmp($::puppetversion,'3.6.1') >= 0 {
 
 node default {
   require ::standard_env
+  require ::standard_env::tools::cucumber
 
   service { 'firewalld':
     ensure => 'stopped',


### PR DESCRIPTION
This pull request provides cucumber as a tool for developers to use when testing.

It requires [standard_env#1](https://github.com/LandRegistry/standard-env/pull/1) to be merged before it can work.
